### PR TITLE
fix: Systems can be added twice because of missing check by type

### DIFF
--- a/lib/src/system/system_manager.dart
+++ b/lib/src/system/system_manager.dart
@@ -22,8 +22,13 @@ class SystemManager {
   }
 
   /// Register a system.
+  ///
+  /// If a given system type has already been added, it will simply return.
   void registerSystem<T extends System>(T system) {
     assert(system.world == null, '$T is already registered');
+    if (_systemsByType.containsKey(system.runtimeType)) {
+      return;
+    }
     system.world = world;
     _systems.add(system);
     _systemsByType[T] = system;

--- a/test/system/system_test.dart
+++ b/test/system/system_test.dart
@@ -80,7 +80,7 @@ void main() {
         final world = World()..registerSystem(system);
 
         expect(
-          () => world..registerSystem(system),
+          () => world.registerSystem(system),
           throwsA(isA<AssertionError>()),
         );
       });

--- a/test/system/system_test.dart
+++ b/test/system/system_test.dart
@@ -42,7 +42,7 @@ class SystemD extends System {
 
 void main() {
   group('System', () {
-    group('registerSystem -', () {
+    group('registerSystem', () {
       test('Priority should be in the right order', () {
         final systemA = SystemA();
         final systemB = SystemB();

--- a/test/system/system_test.dart
+++ b/test/system/system_test.dart
@@ -42,23 +42,48 @@ class SystemD extends System {
 
 void main() {
   group('System', () {
-    test('Priority should be in the right order', () {
-      final systemA = SystemA();
-      final systemB = SystemB();
-      final systemC = SystemC();
-      final systemD = SystemD();
+    group('registerSystem -', () {
+      test('Priority should be in the right order', () {
+        final systemA = SystemA();
+        final systemB = SystemB();
+        final systemC = SystemC();
+        final systemD = SystemD();
 
-      final world = World()
-        ..registerSystem(systemA)
-        ..registerSystem(systemB)
-        ..registerSystem(systemC)
-        ..registerSystem(systemD)
-        ..init();
+        final world = World()
+          ..registerSystem(systemA)
+          ..registerSystem(systemB)
+          ..registerSystem(systemC)
+          ..registerSystem(systemD)
+          ..init();
 
-      expect(
-        world.systemManager.systems,
-        equals([systemC, systemB, systemD, systemA]),
-      );
+        expect(
+          world.systemManager.systems,
+          equals([systemC, systemB, systemD, systemA]),
+        );
+      });
+
+      test('Should not be added if the system type is already registered', () {
+        final world = World()
+          ..registerSystem(SystemA())
+          ..registerSystem(SystemA())
+          ..registerSystem(SystemA())
+          ..registerSystem(SystemA())
+          ..init();
+
+        expect(world.systemManager.systems, hasLength(1));
+      });
+
+      test(
+          'The "system.world == null assertion" should occur when adding a '
+          'system with an initialized world', () {
+        final system = SystemA();
+        final world = World()..registerSystem(system);
+
+        expect(
+          () => world..registerSystem(system),
+          throwsA(isA<AssertionError>()),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

Added a check when adding a system that is already in [`_systemsByType`](https://github.com/Dan-Crane/oxygen/blob/main/lib/src/system/system_manager.dart#L13)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`). 
- [ ] The dart analyzer (`dart analyze`) does not report any problems on my PR.
- [x] I read and followed the [Effective Dart Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I am happy with the current version of this PR and it is ready to be reviewed
- [ ] If the PR still has the `Draft` status, remove it by clicking on the `Ready for review` button in this PR.

## Breaking Change

Does your PR require Oxygen users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR*

<!-- Links -->
[issue database]: https://github.com/flame-engine/oxygen/issues
[Contributor Guide]: https://github.com/flame-engine/oxygen/blob/master/CONTRIBUTING.md
[Effective Dart Style Guide]: https://dart.dev/guides/language/effective-dart/style
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning