### PR TITLE
Component removal and HasNot fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+- Thanks to Bill Haggerty for their contribution of adding proper component removal
+- Fixed HasNot filters to properly filter after a filtered component is added
+- Bumped min dart version to 2.15.0 to allow for constructor tear-offs
+- No breaking changes
+
 ## 0.2.0
 - Made assertion for getting/checking/removing a `Component` stricter
 - **BREAKING**: Made the `priority` field on `System` final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 0.3.0
-- Thanks to Bill Haggerty for their contribution of adding proper component removal
-- Fixed HasNot filters to properly filter after a filtered component is added
-- Bumped min dart version to 2.15.0 to allow for constructor tear-offs
-- No breaking changes
+- Fixed component removal so that it actually removes components
+- Fixed `HasNot` filters to properly filter after a filtered component is added
+- **BREAKING**: Bumped Dart to v2.15.0 to allow for constructor tear-offs
 
 ## 0.2.0
 - Made assertion for getting/checking/removing a `Component` stricter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   pedantic:
     dependency: "direct dev"
     description:

--- a/lib/src/entity/entity.dart
+++ b/lib/src/entity/entity.dart
@@ -10,7 +10,7 @@ class Entity extends PoolObject<String> {
   /// Map of all the components added.
   final Map<Type, Component> _components = {};
 
-  final List<Type> _componentsToRemove = [];
+  final Set<Type> _componentsToRemove = {};
 
   /// Set of all the component types that are added.
   final Set<Type> _componentTypes = {};

--- a/lib/src/entity/entity_manager.dart
+++ b/lib/src/entity/entity_manager.dart
@@ -85,7 +85,7 @@ class EntityManager {
 
     entity._componentTypes.add(T);
     entity._components[T] = component;
-    _queryManager._onComponentAddedToEntity(entity, T);
+    _queryManager._onComponentOfEntityChanged(entity, T);
   }
 
   /// Remove and dispose a component by generics.
@@ -117,8 +117,7 @@ class EntityManager {
     entity._componentTypes.remove(componentType);
     final component = entity._components.remove(componentType);
     component?.dispose();
-
-    _queryManager._onComponentRemovedFromEntity(entity, componentType);
+    _queryManager._onComponentOfEntityChanged(entity, componentType);
   }
 
   /// Removes all the components the given entity has.

--- a/lib/src/entity/entity_manager.dart
+++ b/lib/src/entity/entity_manager.dart
@@ -113,11 +113,10 @@ class EntityManager {
     if (!entity._componentTypes.contains(componentType)) {
       return;
     }
-
+    entity._componentsToRemove.remove(componentType);
     entity._componentTypes.remove(componentType);
     final component = entity._components.remove(componentType);
     component?.dispose();
-
     _queryManager._onComponentRemovedFromEntity(entity, componentType);
   }
 
@@ -155,6 +154,20 @@ class EntityManager {
     _entitiesToRemove.clear();
   }
 
+  void processRemovedComponents() {
+    // Make a copy so we can update this set while looping over it.
+    _entitiesWithRemovedComponents.forEach(_releaseComponentsFromEntity);
+    _entitiesWithRemovedComponents.clear();
+  }
+
+  /// Fully release and reset an component.
+  void _releaseComponentsFromEntity(Entity entity) {
+    // Make a copy so we can update this set while looping over it.
+    final components = entity._componentsToRemove.toList();
+    components
+        .forEach((component) => _removeComponentFromEntity(entity, component));
+  }
+
   /// Fully release and reset an entity.
   void _releaseEntity(Entity entity) {
     _removeAllComponentFromEntity(entity);
@@ -164,6 +177,8 @@ class EntityManager {
     if (_entitiesByName.containsKey(entity.name)) {
       _entitiesByName.remove(entity.name);
     }
-    entity._pool?.release(entity);
+    entity.dispose();
+    //TODO: Why?
+    //entity._pool?.release(entity);
   }
 }

--- a/lib/src/entity/entity_manager.dart
+++ b/lib/src/entity/entity_manager.dart
@@ -154,8 +154,8 @@ class EntityManager {
     _entitiesToRemove.clear();
   }
 
+  /// Process all removed components from the last execute cycle.
   void processRemovedComponents() {
-    // Make a copy so we can update this set while looping over it.
     _entitiesWithRemovedComponents.forEach(_releaseComponentsFromEntity);
     _entitiesWithRemovedComponents.clear();
   }
@@ -177,8 +177,6 @@ class EntityManager {
     if (_entitiesByName.containsKey(entity.name)) {
       _entitiesByName.remove(entity.name);
     }
-    entity.dispose();
-    //TODO: Why?
-    //entity._pool?.release(entity);
+    entity._pool?.release(entity);
   }
 }

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -13,7 +13,7 @@ class Query {
   final List<Entity> _entities = [];
 
   /// Entities that are found through [_filters].
-  List<Entity> get entities => UnmodifiableListView(_entities);
+  List<Entity> get entities => List.unmodifiable(_entities);
 
   Query(this.entityManager, this._filters) : assert(_filters.isNotEmpty) {
     for (final entity in entityManager._entities) {

--- a/lib/src/query/query_manager.dart
+++ b/lib/src/query/query_manager.dart
@@ -21,7 +21,7 @@ class QueryManager {
     }
   }
 
-  void _onComponentAddedToEntity(Entity entity, Type componentType) {
+  void _onComponentOfEntityChanged(Entity entity, Type componentType) {
     for (final query in _queries.values) {
       // Entity should only be added when all the following conditions are met:
       // - the Entity matches the complete query.
@@ -29,11 +29,7 @@ class QueryManager {
       if (query.match(entity) && !query._entities.contains(entity)) {
         query._entities.add(entity);
       }
-    }
-  }
 
-  void _onComponentRemovedFromEntity(Entity entity, Type componentType) {
-    for (final query in _queries.values) {
       // Entity should only be removed when all the following conditions are met:
       // - the Entity matches the complete query.
       // - the Entity is not already part of the query.

--- a/lib/src/world.dart
+++ b/lib/src/world.dart
@@ -63,5 +63,6 @@ class World {
   void execute(double delta) {
     systemManager._execute(delta);
     entityManager.processRemovedEntities();
+    entityManager.processRemovedComponents();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -345,4 +345,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.0"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.2"
+    version: "1.7.1"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   benchmark:
     dependency: "direct dev"
     description:
@@ -49,14 +49,14 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.5"
   collection:
     dependency: transitive
     description:
@@ -70,63 +70,63 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.2"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
@@ -140,14 +140,14 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: "direct main"
     description:
@@ -161,35 +161,21 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
@@ -217,35 +203,35 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.1.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+1"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -301,21 +287,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.18.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.5"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.4.4"
   typed_data:
     dependency: transitive
     description:
@@ -329,34 +315,34 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: oxygen
 description: A lightweight Entity Component System framework written in Dart
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/flame-engine/oxygen
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   meta: ^1.3.0

--- a/test/components/component_test.dart
+++ b/test/components/component_test.dart
@@ -1,0 +1,58 @@
+import 'package:oxygen/oxygen.dart';
+import 'package:test/test.dart';
+
+class TestComponent extends ValueComponent<void> {}
+
+class ComponentAdderSystem extends System {
+  late Query query;
+  @override
+  void init() {
+    query = createQuery([HasNot<TestComponent>()]);
+  }
+
+  @override
+  void execute(double delta) {
+    for (final entity in query.entities) {
+      entity.add<TestComponent, void>();
+    }
+  }
+}
+
+class ComponentRemoverSystem extends System {
+  late Query query;
+  @override
+  void init() {
+    query = createQuery([Has<TestComponent>()]);
+  }
+
+  @override
+  void execute(double delta) {
+    for (final entity in query.entities) {
+      entity.remove<TestComponent>();
+    }
+  }
+}
+
+void main() {
+  group('Component', () {
+    test('Components should be added and removed from entities.', () {
+      final world = World();
+      world.registerComponent<TestComponent, void>(() => TestComponent());
+      world.registerSystem(ComponentRemoverSystem());
+      world.registerSystem(ComponentAdderSystem());
+      var testEntity = world.createEntity('Test Entity');
+      world.init();
+
+      expect(false, testEntity.has<TestComponent>(),
+          reason: 'Entity has component it shouldnt.');
+      world.execute(1);
+      testEntity = world.entities.first;
+      expect(true, testEntity.has<TestComponent>(),
+          reason: 'Entity does not have required component.');
+      world.execute(1);
+      testEntity = world.entities.first;
+      expect(false, testEntity.has<TestComponent>(),
+          reason: 'Entity has component it shouldnt.');
+    });
+  });
+}

--- a/test/components/component_test.dart
+++ b/test/components/component_test.dart
@@ -37,7 +37,7 @@ void main() {
   group('Component', () {
     test('Components should be added and removed from entities.', () {
       final world = World();
-      world.registerComponent<TestComponent, void>(() => TestComponent());
+      world.registerComponent<TestComponent, void>(TestComponent.new);
       world.registerSystem(ComponentRemoverSystem());
       world.registerSystem(ComponentAdderSystem());
       var testEntity = world.createEntity('Test Entity');

--- a/test/components/component_test.dart
+++ b/test/components/component_test.dart
@@ -43,16 +43,29 @@ void main() {
       var testEntity = world.createEntity('Test Entity');
       world.init();
 
-      expect(false, testEntity.has<TestComponent>(),
-          reason: 'Entity has component it shouldnt.');
+      expect(
+        false,
+        testEntity.has<TestComponent>(),
+        reason: 'Entity has component it shouldnt.',
+      );
+
       world.execute(1);
+
       testEntity = world.entities.first;
-      expect(true, testEntity.has<TestComponent>(),
-          reason: 'Entity does not have required component.');
+      expect(
+        true,
+        testEntity.has<TestComponent>(),
+        reason: 'Entity does not have required component.',
+      );
+
       world.execute(1);
+
       testEntity = world.entities.first;
-      expect(false, testEntity.has<TestComponent>(),
-          reason: 'Entity has component it shouldnt.');
+      expect(
+        false,
+        testEntity.has<TestComponent>(),
+        reason: 'Entity has component it shouldnt.',
+      );
     });
   });
 }

--- a/test/components/hasnot_test.dart
+++ b/test/components/hasnot_test.dart
@@ -1,0 +1,49 @@
+import 'package:oxygen/oxygen.dart';
+import 'package:test/test.dart';
+
+class ComponentA extends ValueComponent<void> {}
+
+class ComponentB extends ValueComponent<void> {}
+
+class InitSystem extends System {
+  late final Query initQuery;
+  late final Query query;
+  @override
+  void init() {
+    initQuery = createQuery([Has<ComponentA>(), HasNot<ComponentB>()]);
+    query = createQuery([Has<ComponentA>(), Has<ComponentB>()]);
+  }
+
+  @override
+  void execute(double delta) {
+    for (final entity in initQuery.entities) {
+      entity.add<ComponentB, void>();
+    }
+  }
+}
+
+void main() {
+  group('component', () {
+    test('HasNot should filter newly added components.', () {
+      final world = World();
+      world.registerComponent<ComponentA, void>(() => ComponentA());
+      world.registerComponent<ComponentB, void>(() => ComponentB());
+      final initSystem = InitSystem();
+      world.registerSystem(initSystem);
+      world.init();
+      final entity = world.createEntity('Test')..add<ComponentA, void>();
+      expect(initSystem.initQuery.entities.length, 1,
+          reason: 'initQuery should have the single added entity');
+      expect(initSystem.query.entities.length, 0,
+          reason: 'query should not have the single added entity');
+      world.execute(1);
+      expect(entity.has<ComponentB>(), true,
+          reason: 'Entity should have ComponentB');
+      expect(initSystem.initQuery.entities.length, 0,
+          reason:
+              'initQuery should not have the entity after ComponentB was added.');
+      expect(initSystem.query.entities.length, 1,
+          reason: 'query should have the entity after ComponentB was added.');
+    });
+  });
+}

--- a/test/components/hasnot_test.dart
+++ b/test/components/hasnot_test.dart
@@ -23,7 +23,7 @@ class InitSystem extends System {
 }
 
 void main() {
-  group('component', () {
+  group('Component', () {
     test('HasNot should filter newly added components.', () {
       final world = World();
       world.registerComponent<ComponentA, void>(() => ComponentA());
@@ -31,19 +31,38 @@ void main() {
       final initSystem = InitSystem();
       world.registerSystem(initSystem);
       world.init();
+
       final entity = world.createEntity('Test')..add<ComponentA, void>();
-      expect(initSystem.initQuery.entities.length, 1,
-          reason: 'initQuery should have the single added entity');
-      expect(initSystem.query.entities.length, 0,
-          reason: 'query should not have the single added entity');
+
+      expect(
+        initSystem.initQuery.entities.length,
+        1,
+        reason: 'initQuery should have the single added entity',
+      );
+      expect(
+        initSystem.query.entities.length,
+        0,
+        reason: 'query should not have the single added entity',
+      );
+
       world.execute(1);
-      expect(entity.has<ComponentB>(), true,
-          reason: 'Entity should have ComponentB');
-      expect(initSystem.initQuery.entities.length, 0,
-          reason:
-              'initQuery should not have the entity after ComponentB was added.');
-      expect(initSystem.query.entities.length, 1,
-          reason: 'query should have the entity after ComponentB was added.');
+
+      expect(
+        entity.has<ComponentB>(),
+        true,
+        reason: 'Entity should have ComponentB',
+      );
+      expect(
+        initSystem.initQuery.entities.length,
+        0,
+        reason:
+            'initQuery should not have the entity after ComponentB was added.',
+      );
+      expect(
+        initSystem.query.entities.length,
+        1,
+        reason: 'query should have the entity after ComponentB was added.',
+      );
     });
   });
 }


### PR DESCRIPTION
## Description
fixes #9 
fixes #12 
Merges Bill Haggerty's fork for their component removal fix and my HasNot fix.

As Oxygen is written currently, components are marked for removal but never actually removed, and HasNot filters don't work for components that are added after initialization. This PR fixes both of these two issues. Also bumped the min dart version to allow for constructor tear-offs.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`). 
- [x] The dart analyzer (`dart analyze`) does not report any problems on my PR.
- [x] I read and followed the [Effective Dart Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I am happy with the current version of this PR and it is ready to be reviewed

## Breaking Change

Does your PR require Oxygen users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

- #9 
- #12 

<!-- Links -->
[issue database]: https://github.com/flame-engine/oxygen/issues
[Contributor Guide]: https://github.com/flame-engine/oxygen/blob/master/CONTRIBUTING.md
[Effective Dart Style Guide]: https://dart.dev/guides/language/effective-dart/style
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning