### PR TITLE
ci: Pipeline should use dart pub

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: cedx/setup-dart@v2
       - run: dart pub get
-      - run: dartdoc --no-auto-include-dependencies --quiet
-      
+      - run: dart pub run dartdoc --no-auto-include-dependencies --quiet
+
   format: 
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +43,7 @@ jobs:
       - uses: cedx/setup-dart@v2
       - run: dart pub get
       - run: dart test
-  
+
   benchmark:
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: cicd
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cedx/setup-dart@v2
-      - run: pub get
+      - run: dart pub get
       - run: dartdoc --no-auto-include-dependencies --quiet
       
   format: 
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cedx/setup-dart@v2
-      - run: pub get
+      - run: dart pub get
       - run: dart analyze --fatal-infos --fatal-warnings
   # END LINTING STAGE
 
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cedx/setup-dart@v2
-      - run: pub get
+      - run: dart pub get
       - run: dart test
   
   benchmark:
@@ -50,6 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cedx/setup-dart@v2
-      - run: pub get
-      - run: pub run benchmark
+      - run: dart pub get
+      - run: dart pub run benchmark
   # END TESTING STAGE

--- a/lib/src/pooling/object_pool.dart
+++ b/lib/src/pooling/object_pool.dart
@@ -32,8 +32,8 @@ abstract class ObjectPool<T extends PoolObject<V>, V> {
     }
     final object = _pool.removeLast();
     assert(
-      data == null || data is V,
-      '$T expects an instance of $V but received ${data.runtimeType}',
+      data == null,
+      '$T expects an instance of $V but received null',
     );
     return object..init(data);
   }

--- a/lib/src/pooling/object_pool.dart
+++ b/lib/src/pooling/object_pool.dart
@@ -31,10 +31,6 @@ abstract class ObjectPool<T extends PoolObject<V>, V> {
       expand((_count * 0.2).floor() + 1);
     }
     final object = _pool.removeLast();
-    assert(
-      data == null,
-      '$T expects an instance of $V but received null',
-    );
     return object..init(data);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
+  dartdoc: ^6.1.1
   test: ^1.16.5
   benchmark: ^0.3.0
   pedantic: ^1.11.0


### PR DESCRIPTION
## Description

This fixes the broken pipeline, which was using `pub` directly instead of `dart pub`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`). 
- [x] The dart analyzer (`dart analyze`) does not report any problems on my PR.
- [x] I read and followed the [Effective Dart Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I am happy with the current version of this PR and it is ready to be reviewed
- [x] If the PR still has the `Draft` status, remove it by clicking on the `Ready for review` button in this PR.

## Breaking Change

Does your PR require Oxygen users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR*

<!-- Links -->
[issue database]: https://github.com/flame-engine/oxygen/issues
[Contributor Guide]: https://github.com/flame-engine/oxygen/blob/master/CONTRIBUTING.md
[Effective Dart Style Guide]: https://dart.dev/guides/language/effective-dart/style
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning